### PR TITLE
fix: some yul commands cause compile error (iszero, eq, etc)

### DIFF
--- a/test/lib/YulDeployer.sol
+++ b/test/lib/YulDeployer.sol
@@ -9,7 +9,7 @@ contract YulDeployer is Test {
     ///@param fileName - The file name of the Yul contract. For example, the file name for "Example.yul" is "Example"
     ///@return deployedAddress - The address that the contract was deployed to
     function deployContract(string memory fileName) public returns (address) {
-        string memory bashCommand = string.concat('cast abi-encode "f(bytes)" $(solc --yul yul/', string.concat(fileName, ".yul --bin | tail -1)"));
+        string memory bashCommand = string.concat('cast abi-encode "f(bytes)" $(solc --strict-assembly yul/', string.concat(fileName, ".yul --bin | tail -1)"));
 
         string[] memory inputs = new string[](3);
         inputs[0] = "bash";


### PR DESCRIPTION
`forge test` throw an error due to the some of yul functions such as `iszero` or `eq`, etc.

I will leave here an example code in order to reproduce the issue.

```yul
// yul contract
object "CompileTest" {
    code {
        datacopy(0, dataoffset("Runtime"), datasize("Runtime"))
        return(0, datasize("Runtime"))
    }

    object "Runtime" {
        code {
            function lte(a, b) -> r {
                r := iszero(gt(a, b))
            }

            function returnUint(v) {
                mstore(0, v)
                return(0, 0x20)
            }
        }
    }
}
```

and test code

```solidity
// CompileTest.t.sol
pragma solidity 0.8.15;

import "forge-std/Test.sol";
import "./lib/YulDeployer.sol"; 

interface CompileTest {}

contract CompileTestTest is Test {
    YulDeployer yulDeployer = new YulDeployer();

    CompileTest compileTestContract;

    function setUp() public {
        compileTestContract = CompileTest(yulDeployer.deployContract("CompileTest"));
    }

    function testExample() public {
        // Don't do anything
    }
}
```

the error:
```
stderr err="Error: Function "iszero" not found.
  --> yul/CompileTest.yul:10:22:
   |
10 |                 r := iszero(gt(a, b))
   |                      ^^^^^^

Error: Variable count for assignment to "r" does not match number of values (1 vs. 0)
  --> yul/CompileTest.yul:10:17:
   |
10 |                 r := iszero(gt(a, b))
   |                 ^^^^^^^^^^^^^^^^^^^^^

Error: 
u{1b}[31mInvalid datau{1b}[0m
"
2023-02-25T06:33:11.819759Z ERROR forge::runner: setUp failed reason="EvmError: Revert" contract=0x7fa9385be102ac3eac297483dd6233d62b3e1496
```
