### PR TITLE
Update foundry.toml: change [default] to [profile.default]

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,4 +1,4 @@
-[default]
+[profile.default]
 src = 'src'
 out = 'out'
 libs = ['lib']


### PR DESCRIPTION
[default] profile has been deprecated and will be replaced with [profile.default] in future foundry versions. Update to avoid the warning that pops up at compilation.