### PR TITLE
Fix error

### DIFF
--- a/test/lib/YulDeployer.sol
+++ b/test/lib/YulDeployer.sol
@@ -9,7 +9,7 @@ contract YulDeployer is Test {
     ///@param fileName - The file name of the Yul contract. For example, the file name for "Example.yul" is "Example"
     ///@return deployedAddress - The address that the contract was deployed to
     function deployContract(string memory fileName) public returns (address) {
-        string memory bashCommand = string.concat('cast abi-encode "f(bytes)" $(solc --yul yul/', string.concat(fileName, ".yul --bin | tail -1)"));
+        string memory bashCommand = string.concat('cast abi-encode "f(bytes)" $(solc --yul yul/', string.concat(fileName, ".yul --bin | tail -2)"));
 
         string[] memory inputs = new string[](3);
         inputs[0] = "bash";


### PR DESCRIPTION
```
2023-08-19T06:55:36.259401Z ERROR apply:ext: evm::cheatcodes: non-empty stderr args=["bash", "-c", "cast abi-encode \"f(bytes)\" $(solc --yul yul/Example.yul --bin | tail -1)"] stderr="Error: \n\u{1b}[31mCould not ABI encode the function and arguments. Did you pass in the right types?\nError\nInvalid data\u{1b}[0m\n"
2023-08-19T06:55:36.259713Z ERROR forge::runner: setUp failed reason="EvmError: Revert" contract=0x7fa9385be102ac3eac297483dd6233d62b3e1496
```